### PR TITLE
feat: add param useXvfbDirect when gen pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ test_data/*.pdf
 
 # Temporary generated fils
 temp*
+
+# IDE
+.idea/

--- a/document_test.go
+++ b/document_test.go
@@ -119,7 +119,7 @@ func TestFaultyTempDir(t *testing.T) {
 	pg2, _ := NewPageReader(bytes.NewBufferString("test2"))
 	doc.AddPages(pg1, pg2)
 
-	_, err := doc.createPDF()
+	_, err := doc.createPDF(true)
 	if err == nil {
 		t.Errorf("Error expected, got nil")
 	} else if !strings.HasPrefix(err.Error(), "Error writing temp files") {
@@ -175,7 +175,7 @@ func TestFaultyExecutable(t *testing.T) {
 	doc.AddPages(pg)
 
 	buf := &bytes.Buffer{}
-	err := doc.Write(buf)
+	err := doc.Write(buf, false)
 	if err == nil {
 		t.Errorf("Error expected, got nil")
 	} else if !strings.HasPrefix(err.Error(), "Error running wkhtmltopdf") {

--- a/example_server_test.go
+++ b/example_server_test.go
@@ -35,7 +35,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("Content-Disposition", `attachment; filename="test.pdf"`)
-	err = doc.Write(w)
+	err = doc.Write(w, false)
 	if err != nil {
 		log.Fatal("Error serving pdf")
 	}

--- a/wkhtmltopdf_test.go
+++ b/wkhtmltopdf_test.go
@@ -28,7 +28,7 @@ func TestWriteToFile(t *testing.T) {
 		for _, pg := range tc.Pages {
 			doc.AddPages(NewPage(pg))
 		}
-		err := doc.WriteToFile(tc.Filename)
+		err := doc.WriteToFile(tc.Filename, false)
 		switch {
 		case err == nil && tc.Err != "":
 			t.Errorf("%v. Wrong error produced. Expected: %v, Got: %v", tc.Case, tc.Err, err)
@@ -65,7 +65,7 @@ func TestWriteToReader(t *testing.T) {
 		for _, pg := range tc.Pages {
 			doc.AddPages(NewPage(pg))
 		}
-		err := doc.Write(tc.Writer)
+		err := doc.Write(tc.Writer, false)
 		switch {
 		case err == nil && tc.Err != "":
 			t.Errorf("%v. Wrong error produced. Expected: %v, Got: %v", tc.Case, tc.Err, err)
@@ -97,7 +97,7 @@ func TestWriteFromReader(t *testing.T) {
 	doc.AddPages(pg)
 
 	output := &bytes.Buffer{}
-	err = doc.Write(output)
+	err = doc.Write(output, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestMultipleReaders(t *testing.T) {
 	doc.AddPages(pages[1:]...)
 
 	output := &bytes.Buffer{}
-	err := doc.Write(output)
+	err := doc.Write(output, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
Add param useXvfbDirect(bool) when gen pdf, specify use xvfb to run wkhtmltopdf cmd directly.
The old code use xvfb after normal call fails, which would take dozens of seconds.

Evidence coms below:

/# date
Fri Nov  1 14:56:16 CST 2019

/# wkhtmltopdf --dpi 800 --margin-bottom 0mm --margin-top 0mm --margin-left 0mm --margin-right 0mm a.html c.pdf
QXcbConnection: Could not connect to display
Aborted (core dumped)

/# date
Fri Nov  1 14:57:20 CST 2019